### PR TITLE
#8 CI build fails

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      CI: true
+      working-directory: ./server
 
     strategy:
       matrix:
@@ -22,9 +25,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-        working-directory: ./server
       - run: npm install
       - run: npm test
-        env:
-          CI: true
 

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -22,9 +22,9 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+        working-directory: ./server
       - run: npm install
       - run: npm test
         env:
           CI: true
-        working-directory: ./server
 

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -14,22 +14,17 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [12.x]
 
     steps:
       - uses: actions/checkout@v2
+
       - name: install
         working-directory: ./server
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
         run: npm install
 
       - name: test
         working-directory: ./server
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
         run: npm test
 
     env:

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -11,9 +11,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      CI: true
-      working-directory: ./server
 
     strategy:
       matrix:
@@ -21,10 +18,19 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: install
+        working-directory: ./server
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm install
-      - run: npm test
+        run: npm install
 
+      - name: test
+        working-directory: ./server
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+        run: npm test
+
+    env:
+      CI: true

--- a/server/package.json
+++ b/server/package.json
@@ -4,8 +4,8 @@
   "description": "my expense tracker",
   "main": "dist/server.js",
   "scripts": {
-    "start": "../node_modules/.bin/tsc && node ./dist/server.js",
-    "build": "../node_modules/.bin/tsc",
+    "start": "tsc && node ./dist/server.js",
+    "build": "tsc",
     "test": "jasmine --config=jasmine.json"
   },
   "author": "Mileshko Alesia",


### PR DESCRIPTION
There were two problems:
- Explicit path to `node_modules` executables, which is unnecessary in case when working directory has `node_modules` as a child.
- Currently GitHub Actions option `working-directory` not work with `uses` thus needs to be provided per-step. At leas as I investigate it. 